### PR TITLE
Jakeware/camera msg debug

### DIFF
--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -153,7 +153,9 @@ class SVISNodelet : public nodelet::Nodelet {
         rawhid_close(0);
         return;
       } else if (num == 0) {
-        NODELET_INFO("(svis_ros) 0 bytes received");
+        if (!init_flag_) {
+          NODELET_INFO("(svis_ros) 0 bytes received");
+        }
       } else if (num > 0) {
         t_loop_start_ = ros::Time::now();
 

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -125,17 +125,11 @@ class SVISNodelet : public nodelet::Nodelet {
       NODELET_INFO("(svis_ros) Found svis_teensy device\n");
     }
 
-    // send config packet
-    std::vector<char> buf(64, 0);
-    buf[0] = 0xAB;
-    buf[1] = 0xCD;
-    NODELET_INFO("(svis_ros) Sending configuration packet...");
-    rawhid_send(0, buf.data(), buf.size(), 100);
-    buf.clear();
-    buf.resize(64);
-    NODELET_INFO("(svis_ros) Complete");
+    // send setup packet
+    SendSetup();
 
     // loop
+    std::vector<char> buf(64, 0);
     while (ros::ok() && !stop_signal_) {
       // period
       t_period_ = ros::Time::now();
@@ -328,6 +322,15 @@ class SVISNodelet : public nodelet::Nodelet {
     CameraPacket camera;
     StrobePacket strobe;
   };
+
+  void SendSetup() {
+    std::vector<char> buf(64, 0);
+    buf[0] = 0xAB;
+    buf[1] = 0;
+    NODELET_INFO("(svis_ros) Sending configuration packet...");
+    rawhid_send(0, buf.data(), buf.size(), 100);
+    NODELET_INFO("(svis_ros) Complete");
+  }
 
   int GetChecksum(std::vector<char> &buf) {
     tic();

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -751,7 +751,7 @@ class SVISNodelet : public nodelet::Nodelet {
 
         // handle rollover
         if (diff == 255) {
-          NODELET_WARN("(svis_ros) Handle rollover");
+          // NODELET_WARN("(svis_ros) Handle rollover");
           diff = 1;
         }
       } else {

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -907,7 +907,7 @@ class SVISNodelet : public nodelet::Nodelet {
 
         // check for stale entry and delete
         if ((ros::Time::now().toSec() - (*it_strobe).timestamp_ros_rx) > 1.0) {
-          // NODELET_INFO("delete stale strobe");
+          NODELET_WARN("(svis ros) Delete stale strobe");
           it_strobe = strobe_buffer_.erase(it_strobe);
         } else {
           // NODELET_INFO("increment strobe");

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -219,6 +219,10 @@ class SVISNodelet : public nodelet::Nodelet {
 
         timing_.loop = (ros::Time::now() - t_loop_start_).toSec();
         PublishTiming();
+
+        if (use_camera_ && !received_camera_) {
+          NODELET_WARN_THROTTLE(0.5, "(svis_ros) Have not received camera message");
+        }
       } else {
         NODELET_WARN("(svis_ros) Bad return value from rawhid_recv");
       }
@@ -682,6 +686,10 @@ class SVISNodelet : public nodelet::Nodelet {
 
   void CameraCallback(const sensor_msgs::Image::ConstPtr& image_msg,
                      const sensor_msgs::CameraInfo::ConstPtr& info_msg) {
+    if (!received_camera_) {
+      received_camera_ = true;
+    }
+
     // PrintMetaDataRaw(image_msg);
     CameraPacket camera_packet;
 
@@ -1054,6 +1062,10 @@ class SVISNodelet : public nodelet::Nodelet {
   boost::circular_buffer<StrobePacket> strobe_buffer_;
   boost::circular_buffer<CameraPacket> camera_buffer_;
   boost::circular_buffer<CameraStrobePacket> camera_strobe_buffer_;
+
+  // configuration
+  bool use_camera_ = true;
+  bool received_camera_ = false;
 
   // imu
   int imu_filter_size_ = 5;

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -55,7 +55,7 @@ class SVISNodelet : public nodelet::Nodelet {
    * tells the other threads to stop.
    */
   static void signal_handler(int signal) {
-    printf("SIGINT Received!\n");
+    printf("(svis_ros) SIGINT received\n");
 
     // Tell other threads to stop.
     SVISNodelet::stop_signal_ = 1;

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -515,6 +515,11 @@ class SVISNodelet : public nodelet::Nodelet {
       imu_buffer_.push_back(imu);
     }
 
+    // warn if buffer is at max size
+    if (imu_buffer_.size() == imu_buffer_.max_size()) {
+      NODELET_WARN("(svis_ros) imu buffer at max size");
+    }
+
     timing_.push_imu = toc();
   }
 
@@ -525,6 +530,11 @@ class SVISNodelet : public nodelet::Nodelet {
     for (int i = 0; i < strobe_packets.size(); i++) {
       strobe = strobe_packets[i];
       strobe_buffer_.push_back(strobe);
+    }
+
+    // warn if buffer is at max size
+    if (strobe_buffer_.size() == strobe_buffer_.max_size()) {
+      NODELET_WARN("(svis_ros) strobe buffer at max size");
     }
 
     timing_.push_strobe = toc();
@@ -708,6 +718,11 @@ class SVISNodelet : public nodelet::Nodelet {
 
     // add to buffer
     camera_buffer_.push_back(camera_packet);
+
+    // warn if buffer is at max size
+    if (camera_buffer_.size() == camera_buffer_.max_size() && !sync_flag_) {
+      NODELET_WARN("(svis_ros) camera buffer at max size");
+    }
   }
 
   void GetStrobeTotal(std::vector<StrobePacket> &strobe_packets) {

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -128,7 +128,7 @@ class SVISNodelet : public nodelet::Nodelet {
     // send config packet
     std::vector<char> buf(64, 0);
     buf[0] = 0xAB;
-    buf[1] = 0xBC;
+    buf[1] = 0xCD;
     NODELET_INFO("(svis_ros) Sending configuration packet...");
     rawhid_send(0, buf.data(), buf.size(), 100);
     buf.clear();

--- a/teensy/src/svis_teensy.cpp
+++ b/teensy/src/svis_teensy.cpp
@@ -354,24 +354,67 @@ void InitInterrupts() {
   // attachInterrupt(IMU_INT_PIN, ReadIMU, RISING);  // read imu
 }
 
-void Blink() {
+void BlinkInit() {
   digitalWriteFast(LED_PIN, HIGH);
-  delay(300);
+  delay(200);
   digitalWriteFast(LED_PIN, LOW);
-  delay(300);
+  delay(200);
   digitalWriteFast(LED_PIN, HIGH);
-  delay(300);
+  delay(200);
   digitalWriteFast(LED_PIN, LOW);
-  delay(300);
+  delay(200);
   digitalWriteFast(LED_PIN, HIGH);
-  delay(300);
+  delay(200);
   digitalWriteFast(LED_PIN, LOW);
-  delay(300);
+  delay(200);
   digitalWriteFast(LED_PIN, HIGH);
-  delay(300);
+  delay(200);
 
   digitalWriteFast(LED_PIN, LOW);
   delay(2000);
+}
+
+void BlinkSetup() {
+  digitalWriteFast(LED_PIN, HIGH);
+  delay(400);
+  digitalWriteFast(LED_PIN, LOW);
+  delay(100);
+  digitalWriteFast(LED_PIN, HIGH);
+  delay(400);
+  digitalWriteFast(LED_PIN, LOW);
+  delay(100);
+  digitalWriteFast(LED_PIN, HIGH);
+  delay(400);
+  digitalWriteFast(LED_PIN, LOW);
+  delay(100);
+  digitalWriteFast(LED_PIN, HIGH);
+  delay(400);
+}
+
+void BlinkReset() {
+  digitalWriteFast(LED_PIN, HIGH);
+  delay(100);
+  digitalWriteFast(LED_PIN, LOW);
+  delay(400);
+  digitalWriteFast(LED_PIN, HIGH);
+  delay(100);
+  digitalWriteFast(LED_PIN, LOW);
+  delay(400);
+  digitalWriteFast(LED_PIN, HIGH);
+  delay(100);
+  digitalWriteFast(LED_PIN, LOW);
+  delay(400);
+  digitalWriteFast(LED_PIN, HIGH);
+  delay(100);
+}
+
+void Heartbeat() {
+  // wait led to show an unconfigured device
+  if (since_blink > 1000) {
+    since_blink = 0;
+    led_state = !led_state;
+    digitalWriteFast(LED_PIN, led_state);
+  }
 }
 
 void Initialize() {
@@ -380,10 +423,11 @@ void Initialize() {
 
   // setup led for visual feedback
   pinMode(LED_PIN, OUTPUT);
-  Blink();
+  BlinkInit();
 }
 
 void Setup() {
+  BlinkSetup();
   InitComms();
   InitGPIO();
   // InitMPU6050();
@@ -594,6 +638,8 @@ void Send() {
 }
 
 void Reset() {
+  BlinkReset();
+
   // hid usb
   setup_flag = false;
   send_count = 0;
@@ -647,15 +693,6 @@ extern "C" int main() {
         // check whether or not we have setup the device
         if (!setup_flag) {
           // we have not setup the device and need to configure it
-
-          // wait led to show an unconfigured device
-          if (since_blink > 1000) {
-            since_blink = 0;
-            led_state = !led_state;
-            digitalWriteFast(LED_PIN, led_state);
-          }
-
-          // initialize device
           Setup();
         } else {
           // reset state if we have already setup the device
@@ -667,6 +704,11 @@ extern "C" int main() {
     // send usb data
     if (imu_buffer_count >= 3) {
       Send();
+    }
+
+    // indicate idle
+    if (!setup_flag) {
+      Heartbeat();
     }
 
     // debug print statement


### PR DESCRIPTION
Do some cleanup and detail work while investigating how well we are synchronizing camera and strobe messages.  The bottom line is that the synchronization seems to be working and the changes in this branch allow the strobe and camera data streams to be synchronized with 0 count offset.  Given the current implementation, this means that the strobe message in the buffer that was closet in time to a camera message also happens to have the same count as the one in the image from the PointGrey driver.

Note that it is expected that the final bag will have significantly different message counts.  The teensy triggers the camera while the ros code is finding a timing offset from the imu messages.  This leads to many unmatched image messages during the init period, but does not imply a poor synchronization once that period is over.

Also reorganized the main teensy loop to allow for the setup packet to reconfigure some of the parameters.  The implementation of this was left as future work, though.  Currently, sending more than one setup packet will reset the teensy state/counts and it will restart.  It isn't clear that synchronization works properly after this restart and more analysis will have to be done.