### PR TITLE
jakeware/camera_trigger_fix > master

### DIFF
--- a/pointgrey/launch/flea3.launch
+++ b/pointgrey/launch/flea3.launch
@@ -3,6 +3,7 @@
        If not specified, defaults to first camera found. -->
   <arg name="camera_serial" default="0" />
   <arg name="calibrated" default="0" />
+  <arg name="camera_frame" default="camera" />
 
   <!-- Compression can be "jpeg" or "png" -->
   <arg name="compression" default="png" />
@@ -16,7 +17,7 @@
 
     <node pkg="nodelet" type="nodelet" name="camera_nodelet"
           args="load pointgrey_camera_driver/PointGreyCameraNodelet camera_nodelet_manager" >
-      <param name="frame_id" value="camera" />
+      <param name="frame_id" value="$(arg camera_frame)" />
       <param name="serial" value="$(arg camera_serial)" />
 
       <param name="video_mode" value="format7_mode0" />

--- a/pointgrey/launch/flea3.launch
+++ b/pointgrey/launch/flea3.launch
@@ -1,0 +1,55 @@
+<launch>
+   <!-- Determine this using rosrun pointgrey_camera_driver list_cameras.
+       If not specified, defaults to first camera found. -->
+  <arg name="camera_serial" default="0" />
+  <arg name="calibrated" default="0" />
+
+  <!-- Compression can be "jpeg" or "png" -->
+  <arg name="compression" default="png" />
+
+  <group ns="flea3">
+    <param name="image_raw/compressed/format" value="$(arg compression)" />
+    <param name="image_mono/compressed/format" value="$(arg compression)" />
+    <param name="image_color/compressed/format" value="$(arg compression)" />
+
+    <node pkg="nodelet" type="nodelet" name="camera_nodelet_manager" args="manager" />
+
+    <node pkg="nodelet" type="nodelet" name="camera_nodelet"
+          args="load pointgrey_camera_driver/PointGreyCameraNodelet camera_nodelet_manager" >
+      <param name="frame_id" value="camera" />
+      <param name="serial" value="$(arg camera_serial)" />
+
+      <param name="video_mode" value="format7_mode0" />
+      <param name="format7_color_coding" value="raw8" />
+
+      <param name="auto_exposure" value="False" />
+      <param name="auto_sharpness" value="False" />
+
+      <param name="frame_rate" value="60" />
+
+      <param name="auto_gain" value="False" />
+      <param name="gain" value="4" />
+      <param name="scale" value="1.0" />
+
+      <param name="auto_shutter" value="False" />
+      <param name="shutter_speed" value="0.006" />
+
+      <param name="enable_strobe1" value="False" />
+      <param name="strobe1_polarity" value="0" />
+      <param name="strobe1_delay" value="0" />
+      <param name="strobe1_duration" value="0.0" />
+
+      <param name="enable_trigger" value="True" />
+      <param name="trigger_mode" value="mode0" />
+      <param name="trigger_source" value="gpio0" />
+      <param name="trigger_polarity" value="1" />
+      <param name="enable_trigger_delay" value="False" />
+      <param name="trigger_delay" value="0" />
+      <param name="trigger_parameter" value="0" />
+    </node>
+
+    <node pkg="nodelet" type="nodelet" name="image_proc_debayer"
+          args="load image_proc/debayer camera_nodelet_manager">
+    </node>
+  </group>
+</launch>

--- a/pointgrey/launch/flea3.yaml
+++ b/pointgrey/launch/flea3.yaml
@@ -1,0 +1,14 @@
+frame_id: camera
+serial: 0
+video_mode: format7_mode0
+format7_color_coding: raw8
+auto_exposure: false
+auto_sharpness: false
+frame_rate: 60
+auto_gain: false
+gain: 4
+auto_shutter: false
+shutter_speed: 0.005
+enable_strobe1: true
+trigger_mode: Mode1_bulb_trigger
+scale: 0.5

--- a/ros/package.xml
+++ b/ros/package.xml
@@ -16,6 +16,7 @@
   <depend>sensor_msgs</depend>
   <depend>message_generation</depend>
   <depend>fla_utils</depend>
+  <depend>dynamic_reconfigure</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -17,6 +17,9 @@
 #include <image_transport/image_transport.h>
 #include <image_transport/camera_subscriber.h>
 #include <pluginlib/class_list_macros.h>
+#include <dynamic_reconfigure/StrParameter.h>
+#include <dynamic_reconfigure/Reconfigure.h>
+#include <dynamic_reconfigure/Config.h>
 
 #include <fla_utils/param_utils.h>
 
@@ -108,10 +111,47 @@ class SVISNodelet : public nodelet::Nodelet {
     camera_buffer_.set_capacity(20);
     camera_strobe_buffer_.set_capacity(10);
 
+    // set pointgrey camera trigger
+    ConfigureCamera();
+
     // loop
+    NODELET_INFO("Starting loop");
     Run();
 
     return;
+  }
+
+  void ConfigureCamera() {
+    // toggle pointgrey trigger mode
+    dynamic_reconfigure::ReconfigureRequest srv_req;
+    dynamic_reconfigure::ReconfigureResponse srv_resp;
+    dynamic_reconfigure::StrParameter trigger_mode;
+    dynamic_reconfigure::Config conf;
+
+    trigger_mode.name = "trigger_mode";
+    trigger_mode.value = "mode1";
+    conf.strs.push_back(trigger_mode);
+
+    srv_req.config = conf;
+    ros::service::call("/flea3/camera_nodelet/set_parameters", srv_req, srv_resp);
+
+    for (int i = 0; i < srv_resp.config.strs.size(); i++) {
+      NODELET_INFO("name: %s", srv_resp.config.strs[i].name.c_str());
+      NODELET_INFO("value: %s", srv_resp.config.strs[i].value.c_str());
+    }
+
+    conf.strs.clear();
+    trigger_mode.name = "trigger_mode";
+    trigger_mode.value = "mode0";
+    conf.strs.push_back(trigger_mode);
+
+    srv_req.config = conf;
+    ros::service::call("/flea3/camera_nodelet/set_parameters", srv_req, srv_resp);
+
+    for (int i = 0; i < srv_resp.config.strs.size(); i++) {
+      NODELET_INFO("name: %s", srv_resp.config.strs[i].name.c_str());
+      NODELET_INFO("value: %s", srv_resp.config.strs[i].value.c_str());
+    }
   }
 
   void GetParams() {

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -126,32 +126,55 @@ class SVISNodelet : public nodelet::Nodelet {
     dynamic_reconfigure::ReconfigureRequest srv_req;
     dynamic_reconfigure::ReconfigureResponse srv_resp;
     dynamic_reconfigure::StrParameter trigger_mode;
-    dynamic_reconfigure::Config conf;
+    // dynamic_reconfigure::Config conf;
 
     trigger_mode.name = "trigger_mode";
     trigger_mode.value = "mode1";
-    conf.strs.push_back(trigger_mode);
+    srv_req.config.strs.push_back(trigger_mode);
 
-    srv_req.config = conf;
-    ros::service::call("/flea3/camera_nodelet/set_parameters", srv_req, srv_resp);
+    // set param and check for success
+    bool param_set = false;
+    ros::Rate r(10);
+    while (!param_set) {
+      // set trigger mode
+      ros::service::call("/flea3/camera_nodelet/set_parameters", srv_req, srv_resp);
 
-    for (int i = 0; i < srv_resp.config.strs.size(); i++) {
-      NODELET_INFO("name: %s", srv_resp.config.strs[i].name.c_str());
-      NODELET_INFO("value: %s", srv_resp.config.strs[i].value.c_str());
+      // check for success
+      for (int i = 0; i < srv_resp.config.strs.size(); i++) {
+        // NODELET_INFO("name: %s", srv_resp.config.strs[i].name.c_str());
+        // NODELET_INFO("value: %s", srv_resp.config.strs[i].value.c_str());
+        if (srv_resp.config.strs[i].name == "trigger_mode" && srv_resp.config.strs[i].value == trigger_mode.value) {
+          param_set = true;
+        }
+      }
+
+      r.sleep();
     }
 
-    conf.strs.clear();
+    // reset configure params
+    srv_req.config.strs.clear();
     trigger_mode.name = "trigger_mode";
     trigger_mode.value = "mode0";
-    conf.strs.push_back(trigger_mode);
+    srv_req.config.strs.push_back(trigger_mode);
 
-    srv_req.config = conf;
-    ros::service::call("/flea3/camera_nodelet/set_parameters", srv_req, srv_resp);
+    // set param and check for success
+    param_set = false;
+    while (!param_set) {
+      // set trigger mode
+      ros::service::call("/flea3/camera_nodelet/set_parameters", srv_req, srv_resp);
 
-    for (int i = 0; i < srv_resp.config.strs.size(); i++) {
-      NODELET_INFO("name: %s", srv_resp.config.strs[i].name.c_str());
-      NODELET_INFO("value: %s", srv_resp.config.strs[i].value.c_str());
+      // check for success
+      for (int i = 0; i < srv_resp.config.strs.size(); i++) {
+        // NODELET_INFO("name: %s", srv_resp.config.strs[i].name.c_str());
+        // NODELET_INFO("value: %s", srv_resp.config.strs[i].value.c_str());
+        if (srv_resp.config.strs[i].name == "trigger_mode" && srv_resp.config.strs[i].value == trigger_mode.value) {
+          param_set = true;
+        }
+      }
+
+      r.sleep();
     }
+
   }
 
   void GetParams() {


### PR DESCRIPTION
Waiting on #5.

This little maneuver gets the flea3 camera out of a broken state that it ends up in after boot.  For some reason the trigger configuration is not getting set properly on the camera.  After playing around with the dynamic reconfigure plugin in rqt, it seems like touch any of the trigger params causes it to resend the configuration and everything starts working again.

I know this is super dirty, but I feel like it is better than touching the camera driver.

Resolves: #10