### PR TITLE
Jakeware/add trigger pulse

### DIFF
--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -280,10 +280,10 @@ class SVISNodelet : public nodelet::Nodelet {
         PublishImu(imu_packets_filt);
 
         // sync the camera and strobe counts
-        if (sync_flag_) {
-          GetCountOffset();
-          continue;
-        }
+        // if (sync_flag_) {
+        //   GetCountOffset();
+        //   continue;
+        // }
 
         // PrintStrobeBuffer();
         // PrintCameraBuffer();
@@ -414,6 +414,7 @@ class SVISNodelet : public nodelet::Nodelet {
     NODELET_INFO("(svis_ros) Sending pulse packet");
     rawhid_send(0, buf.data(), buf.size(), 100);
     sent_pulse_ = true;
+    t_pulse_ = ros::Time::now();
   }
 
   void SendDisablePulse() {
@@ -470,7 +471,7 @@ class SVISNodelet : public nodelet::Nodelet {
   }
 
   void GetTimeOffset() {
-    if (time_offset_vec_.size() >= 1000) {
+    if (time_offset_vec_.size() >= 100) {
       // turn off camera pulse
       SendDisablePulse();
 
@@ -490,20 +491,42 @@ class SVISNodelet : public nodelet::Nodelet {
       // calculate final time offset
       time_offset_ = sum / static_cast<double>(time_offset_vec_.size());
       NODELET_INFO("(svis_ros) time_offset: %f", time_offset_);
-    } else {
-      // check strobe_buffer size
-      if (strobe_buffer_.size() == 1 && camera_buffer_.size() == 1) {
-        StrobePacket strobe = strobe_buffer_.front();
-        CameraPacket camera = camera_buffer_.front();
-        time_offset_vec_.push_back(camera.image.header.stamp.toSec() - strobe.timestamp_teensy);
-        strobe_buffer_.pop_front();
-        camera_buffer_.pop_front();
+
+      init_flag_ = false;
+    }
+
+    // check if we already sent a pulse and we have waiting long enough
+    if (sent_pulse_) {
+      // bail if we haven't waited long enough
+      if ((ros::Time::now() - t_pulse_).toSec() < 0.5) {
+        return;
       }
 
-      // send pulse if we haven't already
-      if (!sent_pulse_) {
-        SendPulse();
+      // check strobe_buffer size
+      if (strobe_buffer_.size() > 0 || camera_buffer_.size() > 0) {
+        // we have exactly one of each
+        if (strobe_buffer_.size() == 1 || camera_buffer_.size() == 1) {
+          StrobePacket strobe = strobe_buffer_.front();
+          CameraPacket camera = camera_buffer_.front();
+          time_offset_vec_.push_back(camera.image.header.stamp.toSec() - strobe.timestamp_teensy);
+          strobe_count_offset_ = camera.metadata.frame_counter - strobe.count_total;
+          NODELET_INFO("strobe_count_offset: %i", strobe_count_offset_);
+
+          strobe_buffer_.pop_front();
+          camera_buffer_.pop_front();
+        } else {
+          NODELET_WARN("Mismatched strobe and camera buffer sizes");
+
+          // clear buffers to reset counts
+          strobe_buffer_.clear();
+          camera_buffer_.clear();
+        }
+
+        sent_pulse_ = false;
       }
+    } else {
+      // send pulse if we haven't already
+      SendPulse();
     }
   }
 
@@ -1256,6 +1279,7 @@ class SVISNodelet : public nodelet::Nodelet {
   ros::Time t_loop_start_;
   ros::Time t_period_;
   ros::Time t_period_last_;
+  ros::Time t_pulse_;
   ros::Time tic_;
   ros::Time toc_;
   svis_ros::SvisTiming timing_;

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -177,7 +177,6 @@ class SVISNodelet : public nodelet::Nodelet {
 
       r.sleep();
     }
-
   }
 
   void GetParams() {
@@ -424,9 +423,8 @@ class SVISNodelet : public nodelet::Nodelet {
     // accel range
     buf[4] = acc_sens_;  // AFS_SEL
 
-    NODELET_INFO("(svis_ros) Sending configuration packet...");
+    NODELET_INFO("(svis_ros) Sending configuration packet");
     rawhid_send(0, buf.data(), buf.size(), 100);
-    NODELET_INFO("(svis_ros) Complete");
   }
 
   int GetChecksum(std::vector<char> &buf) {

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -505,7 +505,7 @@ class SVISNodelet : public nodelet::Nodelet {
       // check strobe_buffer size
       if (strobe_buffer_.size() > 0 || camera_buffer_.size() > 0) {
         // we have exactly one of each
-        if (strobe_buffer_.size() == 1 || camera_buffer_.size() == 1) {
+        if (strobe_buffer_.size() == 1 && camera_buffer_.size() == 1) {
           StrobePacket strobe = strobe_buffer_.front();
           CameraPacket camera = camera_buffer_.front();
           time_offset_vec_.push_back(camera.image.header.stamp.toSec() - strobe.timestamp_teensy);

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -516,7 +516,8 @@ class SVISNodelet : public nodelet::Nodelet {
           camera_buffer_.pop_front();
         } else {
           NODELET_WARN("Mismatched strobe and camera buffer sizes");
-
+          NODELET_WARN("strobe_buffer size: %lu", strobe_buffer_.size());
+          NODELET_WARN("camera_buffer size: %lu", camera_buffer_.size());
           // clear buffers to reset counts
           strobe_buffer_.clear();
           camera_buffer_.clear();

--- a/ros/src/svis_ros_nodelet.cc
+++ b/ros/src/svis_ros_nodelet.cc
@@ -492,10 +492,12 @@ class SVISNodelet : public nodelet::Nodelet {
       NODELET_INFO("(svis_ros) time_offset: %f", time_offset_);
     } else {
       // check strobe_buffer size
-      if (strobe_buffer_.size() > 0) {
+      if (strobe_buffer_.size() == 1 && camera_buffer_.size() == 1) {
         StrobePacket strobe = strobe_buffer_.front();
-        time_offset_vec_.push_back(strobe.timestamp_ros_rx - strobe.timestamp_teensy);
+        CameraPacket camera = camera_buffer_.front();
+        time_offset_vec_.push_back(camera.image.header.stamp.toSec() - strobe.timestamp_teensy);
         strobe_buffer_.pop_front();
+        camera_buffer_.pop_front();
       }
 
       // send pulse if we haven't already

--- a/teensy/src/svis_teensy.cpp
+++ b/teensy/src/svis_teensy.cpp
@@ -721,8 +721,8 @@ void ResetParams() {
   imu_buffer_head = 0;
   imu_buffer_tail = 0;
   imu_buffer_count = 0;
-  // fs_sel = recv_buffer[2];
-  // afs_sel = recv_buffer[3];
+  // fs_sel = recv_buffer[2];  // can't update this on restart
+  // afs_sel = recv_buffer[3];  //  can't update this on restart
 
   // strobe variables
   strobe_count = 0;


### PR DESCRIPTION
This PR moves away from the approach of using the timestamp of the third IMU packet to estimate the time offset between the two time epochs in order to synchronize the camera messages and strobe packets.  Instead, the camera trigger line is pulsed once and the we wait for the resulting camera image before pulsing again.  This process is repeated N times before calculating a offset between the teensy strobe/pulse count and pointgrey frame count embedded in the image.